### PR TITLE
Parse error resolved for Wordpress 4.9.8

### DIFF
--- a/google-search-profile.php
+++ b/google-search-profile.php
@@ -117,7 +117,7 @@ function gsp_add_schema() {
 			"sameAs" : [ "<?php echo $socialschema; ?>"] 
 			}
 		</script>
-    	<?
+    	<?php
     	}
     }
 }


### PR DESCRIPTION
Parse error caused by openning php with '<?'  is now resolved. 